### PR TITLE
The message should say "less than or equal <number>"

### DIFF
--- a/lib/grape/kaminari/max_value_validator.rb
+++ b/lib/grape/kaminari/max_value_validator.rb
@@ -12,10 +12,11 @@ module Grape
 
         attr = params[attr_name]
         if attr && @option && attr > @option
+          message = "must be less than or equal #{@option}"
           if Gem::Version.new(Grape::VERSION) >= Gem::Version.new('0.9.0')
-            raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: "must be less than #{@option}"
+            raise Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: message
           else
-            raise Grape::Exceptions::Validation, param: @scope.full_name(attr_name), message: "must be less than #{@option}"
+            raise Grape::Exceptions::Validation, param: @scope.full_name(attr_name), message: message
           end
         end
       end


### PR DESCRIPTION
The validator is checking whether passed number is greater than an @option.
If this is true then the exception is raised. However when passed number is equal
the @option the exception is not raised. To make the message correct 
it should state "less than _or equal_ <number>" instead of just "less than".